### PR TITLE
chore: update GitHub Action libraries to latest versions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -2,14 +2,14 @@ name: Code Quality
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
 
 jobs:
   code-quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: install npm dependencies
         run: npm ci
       - name: lint

--- a/.github/workflows/import-accessibility-posts.yml
+++ b/.github/workflows/import-accessibility-posts.yml
@@ -6,23 +6,18 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: '0 12 * * MON'
+    - cron: "0 12 * * MON"
 
 jobs:
   import:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        deno-version: [1.19.2]
-
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
-      - name: Use Deno Version ${{ matrix.deno-version }}
-        uses: denolib/setup-deno@v2
+        uses: actions/checkout@v3
+      - name: Use Deno Version 1.19.2
+        uses: denoland/setup-deno@v1
         with:
-          deno-version: ${{ matrix.deno-version }}
+          deno-version: "1.19.2"
       - name: Import Latest Posts
         run: deno run --allow-read --allow-env --allow-net src/index.ts
         env:


### PR DESCRIPTION
This addresses support for Node.js v12 being deprecated and eventually dropped, which would affect the older versions of `actions/checkout` and `denolib/setup-deno`.